### PR TITLE
Update parse.go

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -24,6 +24,8 @@ var listLineParsers = []parseFunc{
 var dirTimeFormats = []string{
 	"01-02-06  03:04PM",
 	"2006-01-02  15:04",
+	"01-02-2006  03:04PM",
+	"01-02-2006  15:04",
 }
 
 // parseRFC3659ListLine parses the style of directory line defined in RFC 3659.


### PR DESCRIPTION
New time formats for non standard date returned by LIST